### PR TITLE
2) Fixes for https images NOT being downloaded

### DIFF
--- a/resources/lib/downloader.py
+++ b/resources/lib/downloader.py
@@ -72,6 +72,9 @@ class Downloader:
 		xbmc.sleep(500)
 		start_time = time.time()
 		try: 
+            ## ugly #######################
+            url=url.replace('https','http')
+            ################################
 			urllib.urlretrieve(url, path, lambda nb, bs, fs: self.dialogdown(name,nb, bs, fs, dp, start_time))
 			dp.close()
 			try: self.log=self.log+'[B]'+name+'[/B] : '+path+'\n'


### PR DESCRIPTION
Downloading logo(s) in LibreElec (on ARM) always results in a blank (0k) image, certainly due to a bug about the correct  SSL certificate in the https python lib. While this is certainly very long to trace and fix, and as long as the API server ALSO deliver images as http (non SSL), i've patched the download call to always use http instead of https.

The patch is a bit ugly ;-), but it works fine.

BTW If you are also in charge of the server, may I suggest you to just change the API answer, to directly link to NON SSL images. It would be more elegant.

HTH
