### PR TITLE
3) Custom Search defaults to channel Name

### DIFF
--- a/resources/lib/context.py
+++ b/resources/lib/context.py
@@ -34,7 +34,8 @@ def run(channel_name):
 		if menu_functions[choose] == 'auto':
 			channel = urllib.quote_plus(get_replaced_names(channel_name))
 		elif menu_functions[choose] == 'custom':
-			keyb = xbmc.Keyboard('', 'Enter channel')
+			#keyb = xbmc.Keyboard('', 'Enter channel')
+			keyb = xbmc.Keyboard(channel_name, 'Enter channel')
 			keyb.doModal()
 			if (keyb.isConfirmed()):
 				search_parameter = urllib.quote_plus(get_replaced_names(keyb.getText()))


### PR DESCRIPTION
From the context menu there are 2 options : Either search with the exact name, or search with a custom name.

When searching with a custom name, 99% of the time this is because the channel name, slightly need to be changed : ie adding/removing a space in the middle, removing the end, etc...
So this is really boring to type almost the full channel name each time.

This patch add the channel name as the default, so that you just have to fastly change the letters you need. And whenever you'd need to type a totally different name, erasing the whole default channel name, is really fast.

HTH